### PR TITLE
Bump lowest supported to 4.6.2

### DIFF
--- a/source/Caching/Caching.csproj
+++ b/source/Caching/Caching.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
     <TargetFramework>netcoreapp3.1</TargetFramework>


### PR DESCRIPTION
As 4.5.2 is EOL on Apr 26, 2022

A GitHub [search](https://github.com/search?l=XML&q=org%3AOctopusDeploy+octopus.caching&type=Code) shows we are not using it in any projects that need net452.