### PR TITLE
Update package metadata

### DIFF
--- a/source/Caching/Caching.csproj
+++ b/source/Caching/Caching.csproj
@@ -4,7 +4,10 @@
     <Authors>Octopus Deploy</Authors>
     <AssemblyName>Octopus.Caching</AssemblyName>
     <RootNamespace>Octopus.Caching</RootNamespace>
+    <PackageId>Octopus.Caching</PackageId>
+    <Description>A simple caching class.</Description>
     <PackageProjectUrl>https://github.com/OctopusDeploy/Caching</PackageProjectUrl>
+    <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <DisableImplicitPackageTargetFallback>true</DisableImplicitPackageTargetFallback>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Adding some metadata so that the package looks a bit nicer since this package is going to Nuget.org now.
What it currently looks like:
![image](https://user-images.githubusercontent.com/11970672/173716711-2d57f642-d299-4bbf-b222-91c5047259b6.png)

https://www.nuget.org/packages/Octopus.Caching